### PR TITLE
Fix layout in firefox

### DIFF
--- a/src/Boggle.css
+++ b/src/Boggle.css
@@ -87,6 +87,7 @@ ol {
 }
 
 .boggle-board input {
+  width: 35px;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   font-size: 24px;
   font-weight: 400;

--- a/src/BoggleGrid.tsx
+++ b/src/BoggleGrid.tsx
@@ -202,7 +202,9 @@ export function BoggleGrid(props: BoggleGridProps) {
           <strong>{selectedWord}</strong>: {SCORES[selectedWord.length]} point
           {SCORES[selectedWord.length] > 1 ? "s" : ""}
         </div>
-      ) : null}
+      ) : (
+        <div className="selected-word">{" "}</div>
+      )}
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,10 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { SWRConfig } from "swr";
-import "./index.css";
 import App from "./App.tsx";
 import { singletonCache } from "./cache.ts";
+
+import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
Fixes #8 

For some reason `<input type="text" size="2">` winds up ~2x the width in Firefox as in Chrome, which throws off the layout. I tried throwing in a CSS reset but that didn't fix things, so I just pinned the width to its value in Chrome.